### PR TITLE
Pass docker memory limit to nginx-dogu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,44 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added the ability to configure the memory limits with cesapp edit-config; #28
 
 ## [v1.17.8-6] - 2020-11-16
-
 ### Added
-
 - Ability to deliver custom content pages. (#26)
 - SHA256 checks for all manual downloads in the dockerfile
 
 ### Changed
-
 - Update of the base image to v3.11.6-3 
 - Update warp-menu version to v1.0.4
 
 ## [v1.17.8-5] - 2020-07-20
-
 ### Changed
-
 - Update styles so HTTP error pages have all the same text color.
 
 ## [1.17.8-4] - 2020-05-26
-
 ### Changed
-
 - update warp menu to v1.0.3
 
 ## [1.17.8-3] - 2020-05-20
-
 ### Changed
-
 - update warp menu to v1.0.2
 
 ## [1.17.8-2] - 2020-05-12
-
 ### Changed
 - update warp menu to v1.0.1
 
 ## [1.17.8-1] - 2020-01-29
-
 ### Changed
 - Available ciphers
 

--- a/dogu.json
+++ b/dogu.json
@@ -35,6 +35,22 @@
       "Name": "html_content_url",
       "Description": "URL path to reach all custom html content pages. Default value when unset: static",
       "Optional": true
+    },
+    {
+      "Name": "container_config/memory_limit",
+      "Description": "Limits the container's memory usage. Use a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). We recommend to have at least allocated 20m for additional tools (ces-confd) running inside the container.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
+    },
+    {
+      "Name": "container_config/swap_limit",
+      "Description": "Limits the container's swap memory usage. Use zero or a positive integer value followed by one of these units [b,k,m,g] (byte, kibibyte, mebibyte, gibibyte). 0 will disable swapping.",
+      "Optional": true,
+      "Validation": {
+        "Type": "BINARY_MEASUREMENT"
+      }
     }
   ],
   "Volumes": [


### PR DESCRIPTION
Add container_config/memory_limit and container_config/swap_limit options to dogu.json. Update CHANGELOG.md (#28)
Ces-confd allocates ~10MB memory, therefore we added a short recommandation to the dogu.json configuration of  container_config/memory_limit.

Resolves #28 