### PR TITLE
Fix/findversiononce/develop

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,10 @@ node('vagrant') {
             }
 
             stage('Build') {
+                // purge nginx from official namespace to prevent conflicts while building prerelease_official/nginx
+                if (gitflow.isPreReleaseBranch()) {
+                    ecoSystem.purgeDogu("nginx")
+                }
                 ecoSystem.build("/dogu")
             }
 

--- a/build/make/prerelease.sh
+++ b/build/make/prerelease.sh
@@ -22,12 +22,12 @@ prerelease_namespace() {
   # Update version in Dockerfile
   if [ -f "Dockerfile" ]; then
     echo "Updating version in Dockerfile..."
-    ORIG_NAME="$(grep -oP ".*[ ]*NAME=\"([^\"]*)" Dockerfile | awk -F "\"" '{print $2}')"
-    ORIG_VERSION="$(grep -oP ".*[ ]*VERSION=\"([^\"]*)" Dockerfile | awk -F "\"" '{print $2}')"
+    ORIG_NAME="$(grep -oP -m 1 ".*[ ]*NAME=\"([^\"]*)" Dockerfile | awk -F "\"" '{print $2}')"
+    ORIG_VERSION="$(grep -oP -m 1 ".*[ ]*VERSION=\"([^\"]*)" Dockerfile | awk -F "\"" '{print $2}')"
     PRERELEASE_NAME="prerelease_$( echo -e "$ORIG_NAME" | sed 's/\//\\\//g' )"
     PRERELEASE_VERSION="${ORIG_VERSION}${TIMESTAMP}"
-    sed -i "s/\(.*[ ]*NAME=\"\)\([^\"]*\)\(.*$\)/\1${PRERELEASE_NAME}\3/" Dockerfile
-    sed -i "s/\(.*[ ]*VERSION=\"\)\([^\"]*\)\(.*$\)/\1${PRERELEASE_VERSION}\3/" Dockerfile
+    sed -i "s/\(.*[ ]NAME=\"\)\([^\"]*\)\(.*$\)/\1${PRERELEASE_NAME}\3/" Dockerfile
+    sed -i "s/\(.*[ ]VERSION=\"\)\([^\"]*\)\(.*$\)/\1${PRERELEASE_VERSION}\3/" Dockerfile
   fi
 
 }


### PR DESCRIPTION
Nur für develop relevant

* erstellt Release im Prerelease-namespace mit eigener Versionsnummer
* purgen vor dem Build ist notwendig, weil nginx teil der Default Konfiguration der Build-Vagrant VM ist und daher in einem anderen Namespace bereits existiert